### PR TITLE
Fix perlin noise for Stable Cascade

### DIFF
--- a/extra_samplers.py
+++ b/extra_samplers.py
@@ -1,7 +1,7 @@
 import math
 
 import torch
-from torch import nn
+from torch import nn, FloatTensor
 import torchsde
 from tqdm.auto import trange, tqdm
 
@@ -223,7 +223,7 @@ def rand_perlin_like(x):
     noise_size_W = noise.size(dim=3)
     perlin = None
     for i in range(2):
-        noise += perlin_noise((noise_size_H, noise_size_W), (noise_size_H, noise_size_W), batch_size=4).to(x.device)
+        noise += perlin_noise((noise_size_H, noise_size_W), (noise_size_H, noise_size_W), batch_size=x.shape[1]).to(x.device)
     #noise += perlin
     #print(noise)
     return noise / noise.std()


### PR DESCRIPTION
this pull hopefully fixes perlin noise generation for Stable Cascade (or anything that doesn't have 4 channels).

also threw in a tiny fix since there was a `FloatTensor` type annotation but `FloatTensor` wasn't actually defined.